### PR TITLE
Add missing submodules to build on latest arch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -61,11 +61,15 @@ source=(
         "$pkgname-vma::git+https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git"
         "$pkgname-enet::git+https://github.com/lsalzman/enet.git"
         "$pkgname-cubeb::git+https://github.com/mozilla/cubeb.git"
+        "$pkgname-tinygltf::git+https://github.com/syoyo/tinygltf.git"
+        "$pkgname-minizip-ng::git+https://github.com/zlib-ng/minizip-ng.git"
         "$pkgname-sanitizers-cmake::git+https://github.com/arsenm/sanitizers-cmake.git"
         "$pkgname.svg"
         "$pkgname.desktop"
 )
 sha512sums=('SKIP'
+            'SKIP'
+            'SKIP'
             'SKIP'
             'SKIP'
             'SKIP'
@@ -100,6 +104,8 @@ prepare() {
                 [corrosion]='corrosion'
                 [slippi-rust-extensions]='SlippiRustExtensions'
                 [cubeb]='cubeb'
+                [tinygltf]='tinygltf'
+                [minizip-ng]='minizip-ng'
         )
 
         for _submod in "${!_submodules[@]}"; do

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -44,7 +44,7 @@ depends=('alsa-lib'
          'zstd'
 )
 
-makedepends=('cmake3-bin' 'git' 'miniupnpc' 'ninja' 'python' 'qt6-base' 'qt6-svg' 'cargo')
+makedepends=('cmake3-bin' 'git' 'miniupnpc' 'ninja' 'python' 'qt6-base' 'qt6-svg' 'cargo' 'vulkan-devel')
 optdepends=('pulseaudio: PulseAudio backend')
 options=('!lto')
 


### PR DESCRIPTION
After updating `slippi-mainline` to use `cmake3`, two other dependencies were missing from PKGBUILD to allow successful build. 

```
CMake Error at Externals/tinygltf/CMakeLists.txt:8 (target_sources): Cannot find source file:

tinygltf/tiny_gltf.cc

Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc

CMake Error at Externals/minizip-ng/CMakeLists.txt:3 (add_library): Cannot find source file:

minizip-ng/mz.h

Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc

CMake Error at Externals/tinygltf/CMakeLists.txt:1 (add_library): No SOURCES given to target: tinygltf

CMake Error at Externals/minizip-ng/CMakeLists.txt:3 (add_library): No SOURCES given to target: minizip

CMake Generate step failed. Build files cannot be regenerated correctly. ==> ERROR: A failure occurred in build(). Aborting... -
```

Additionally, `vulkan.h` is a requirement on the system.

